### PR TITLE
Add configurable report runner Suitelet

### DIFF
--- a/FileCabinet/SuiteScripts/ReportRunner/report_suitelet.js
+++ b/FileCabinet/SuiteScripts/ReportRunner/report_suitelet.js
@@ -1,0 +1,404 @@
+/**
+ * @NApiVersion 2.1
+ * @NScriptType Suitelet
+ * @NModuleScope SameAccount
+ */
+ define(['N/ui/serverWidget', 'N/search', 'N/record', 'N/query', 'N/runtime', 'N/file', 'N/url'],
+     (ui, search, record, query, runtime, file, url) => {
+ 
+         const CUSTOM_RECORD_TYPE = 'customrecord_rr_report';
+         const FILTER_CONFIG_FIELD = 'custrecord_rr_filter_config';
+         const DATASOURCE_FIELD = 'custrecord_rr_datasource';
+         const SAVED_SEARCH_FIELD = 'custrecord_rr_savedsearch';
+         const SUITEQL_FIELD = 'custrecord_rr_suiteql';
+         const CHART_TYPE_FIELD = 'custrecord_rr_chart_type';
+         const CHART_LABEL_FIELD = 'custrecord_rr_chart_label';
+         const CHART_VALUE_FIELD = 'custrecord_rr_chart_value';
+         const DESCRIPTION_FIELD = 'custrecord_rr_description';
+ 
+         const CHART_JS_CDN = 'https://cdn.jsdelivr.net/npm/chart.js';
+ 
+         const MAX_RESULTS = 2000;
+ 
+         const chartTypes = {
+             none: 'none',
+             bar: 'bar',
+             line: 'line',
+             pie: 'pie',
+             doughnut: 'doughnut'
+         };
+ 
+         const dataSourceTypes = {
+             savedSearch: 'SAVED_SEARCH',
+             suiteql: 'SUITEQL'
+         };
+ 
+         const ACTION_DOWNLOAD = 'download';
+ 
+         const renderReportCatalog = (context) => {
+             const form = ui.createForm({ title: 'Report Runner - Reports' });
+             form.addField({
+                 id: 'custpage_rr_intro',
+                 type: ui.FieldType.INLINEHTML,
+                 label: ' ',
+                 defaultValue: '<div><p>Select a report configuration to launch.</p></div>'
+             });
+ 
+             const sublist = form.addSublist({
+                 id: 'custpage_rr_reports',
+                 type: ui.SublistType.LIST,
+                 label: 'Available Reports'
+             });
+ 
+             sublist.addField({ id: 'custpage_rr_report_name', label: 'Report', type: ui.FieldType.TEXT });
+             sublist.addField({ id: 'custpage_rr_report_description', label: 'Description', type: ui.FieldType.TEXT });
+             sublist.addField({ id: 'custpage_rr_report_link', label: 'Open', type: ui.FieldType.URL }).linkText = 'Open';
+ 
+             const reportSearch = search.create({
+                 type: CUSTOM_RECORD_TYPE,
+                 filters: [['isinactive', 'is', 'F']],
+                 columns: [
+                     search.createColumn({ name: 'name' }),
+                     search.createColumn({ name: DESCRIPTION_FIELD })
+                 ]
+             });
+ 
+             let index = 0;
+             reportSearch.run().each(result => {
+                 const configId = result.id;
+                 const name = result.getValue({ name: 'name' });
+                 const description = result.getValue({ name: DESCRIPTION_FIELD }) || '';
+                 const resolved = url.resolveScript({
+                     scriptId: runtime.getCurrentScript().id,
+                     deploymentId: runtime.getCurrentScript().deploymentId,
+                     params: { report: configId }
+                 });
+                 sublist.setSublistValue({ id: 'custpage_rr_report_name', line: index, value: name || '' });
+                 if (description) {
+                     sublist.setSublistValue({ id: 'custpage_rr_report_description', line: index, value: description });
+                 }
+                 sublist.setSublistValue({ id: 'custpage_rr_report_link', line: index, value: resolved });
+                 index += 1;
+                 return true;
+             });
+ 
+             context.response.writePage(form);
+         };
+ 
+         const parseFilterConfiguration = (configText) => {
+             if (!configText) {
+                 return [];
+             }
+             try {
+                 const parsed = JSON.parse(configText);
+                 return Array.isArray(parsed) ? parsed : [];
+             } catch (e) {
+                 log.error('Invalid filter configuration JSON', e);
+                 return [];
+             }
+         };
+ 
+         const addFilterFieldsToForm = (form, filters, requestParameters) => {
+             const group = form.addFieldGroup({ id: 'custpage_rr_filters', label: 'Filters' });
+             filters.forEach(filter => {
+                 const fieldId = `custpage_filter_${filter.id}`;
+                 const fieldType = (filter.type || 'text').toUpperCase();
+                 let nsFieldType = ui.FieldType.TEXT;
+                 switch (fieldType) {
+                     case 'SELECT':
+                         nsFieldType = ui.FieldType.SELECT;
+                         break;
+                     case 'DATE':
+                         nsFieldType = ui.FieldType.DATE;
+                         break;
+                     case 'CHECKBOX':
+                         nsFieldType = ui.FieldType.CHECKBOX;
+                         break;
+                     case 'FLOAT':
+                     case 'INTEGER':
+                         nsFieldType = ui.FieldType.FLOAT;
+                         break;
+                     default:
+                         nsFieldType = ui.FieldType.TEXT;
+                 }
+ 
+                 const field = form.addField({
+                     id: fieldId,
+                     label: filter.label || filter.id,
+                     type: nsFieldType,
+                     container: group.id
+                 });
+                 if (nsFieldType === ui.FieldType.SELECT && filter.source) {
+                     field.addSelectOption({ value: '', text: '' });
+                     filter.source.forEach(option => {
+                         field.addSelectOption(option);
+                     });
+                 }
+                 const value = requestParameters[fieldId] || requestParameters[filter.id];
+                 if (value !== undefined && value !== null) {
+                     field.defaultValue = value;
+                 }
+             });
+         };
+ 
+         const extractFilterValues = (filters, requestParameters) => {
+             return filters.reduce((memo, filter) => {
+                 const fieldId = `custpage_filter_${filter.id}`;
+                 let value = requestParameters[fieldId];
+                 if (value === undefined) {
+                     value = requestParameters[filter.id];
+                 }
+                 if (value !== undefined && value !== '') {
+                     memo[filter.id] = value;
+                 }
+                 return memo;
+             }, {});
+         };
+ 
+         const runSavedSearch = (searchId, filters, filterValues) => {
+             const loadedSearch = search.load({ id: searchId });
+             const originalFilters = (loadedSearch.filters || []).slice();
+             const columns = (loadedSearch.columns || []).slice();
+             const searchType = loadedSearch.searchType;
+ 
+             const additionalFilters = (filters || []).map(filter => {
+                 const value = filterValues[filter.id];
+                 if (!value) {
+                     return null;
+                 }
+                 const operator = (filter.operator || (filter.type === 'SELECT' ? 'ANYOF' : 'CONTAINS')).toUpperCase();
+                 return search.createFilter({
+                     name: filter.searchField || filter.id,
+                     operator,
+                     values: value
+                 });
+             }).filter(Boolean);
+ 
+             const combinedFilters = originalFilters.concat(additionalFilters);
+ 
+             const createdSearch = search.create({
+                 type: searchType,
+                 filters: combinedFilters,
+                 columns
+             });
+ 
+             const results = [];
+             const paged = createdSearch.runPaged({ pageSize: 1000 });
+             paged.pageRanges.forEach(range => {
+                 const page = paged.fetch({ index: range.index });
+                 page.data.forEach(result => results.push(result));
+             });
+             return results.slice(0, MAX_RESULTS).map(result => {
+                 const record = {};
+                 columns.forEach((column, columnIndex) => {
+                     const key = column.label || column.name || column.join || column.summary || `col_${columnIndex}`;
+                     record[key] = result.getText(column) || result.getValue(column);
+                 });
+                 return record;
+             });
+         };
+ 
+         const runSuiteQL = (suiteQL, filters, filterValues) => {
+             if (!suiteQL) {
+                 return [];
+             }
+             const paramMap = {};
+             const orderedFilters = (filters || []).filter(filter => filter.suiteqlParamIndex !== undefined && filterValues[filter.id] !== undefined)
+                 .sort((a, b) => a.suiteqlParamIndex - b.suiteqlParamIndex);
+             orderedFilters.forEach(filter => {
+                 paramMap[filter.suiteqlParamIndex] = filterValues[filter.id];
+             });
+             const params = [];
+             const indices = Object.keys(paramMap).map(Number).sort((a, b) => a - b);
+             indices.forEach(index => {
+                 params[index] = paramMap[index];
+             });
+
+             const resultSet = query.runSuiteQL({ query: suiteQL, params });
+             const results = resultSet.asMappedResults();
+             return results.slice(0, MAX_RESULTS);
+         };
+ 
+         const convertToTable = (form, data) => {
+             if (!data || data.length === 0) {
+                 return '<p class="rr-empty">No results found for the current selection.</p>';
+            }
+             const headers = Object.keys(data[0]);
+             const rowsHtml = data.map(row => {
+                 const cells = headers.map(header => `<td>${(row[header] ?? '').toString().replace(/</g, '&lt;')}</td>`).join('');
+                 return `<tr>${cells}</tr>`;
+             }).join('');
+             const headerHtml = headers.map(header => `<th>${header}</th>`).join('');
+             return `<table class="rr-table"><thead><tr>${headerHtml}</tr></thead><tbody>${rowsHtml}</tbody></table>`;
+         };
+ 
+         const buildDownloadCsv = (data) => {
+             if (!data || data.length === 0) {
+                 return '';
+            }
+             const headers = Object.keys(data[0]);
+             const escapeValue = (value) => {
+                 if (value === null || value === undefined) {
+                     return '';
+                 }
+                 const stringValue = value.toString();
+                 if (stringValue.includes('"') || stringValue.includes(',') || stringValue.includes('\n')) {
+                     return `"${stringValue.replace(/"/g, '""')}"`;
+                 }
+                 return stringValue;
+             };
+             const lines = [headers.join(',')];
+             data.forEach(row => {
+                 const line = headers.map(header => escapeValue(row[header])).join(',');
+                 lines.push(line);
+             });
+             return lines.join('\n');
+         };
+ 
+         const addDownloadButton = (form) => {
+             const actionField = form.addField({ id: 'custpage_rr_action', type: ui.FieldType.TEXT, label: 'Action' });
+             actionField.updateDisplayType({ displayType: ui.FieldDisplayType.HIDDEN });
+             form.addButton({
+                 id: 'custpage_rr_download',
+                 label: 'Download CSV',
+                 functionName: 'onDownload'
+             });
+             form.clientScriptModulePath = 'SuiteScripts/ReportRunner/report_suitelet_client.js';
+         };
+ 
+         const buildChartHtml = (chartType, chartLabelField, chartValueField, data) => {
+             if (!chartType || chartType === chartTypes.none || !data || data.length === 0) {
+                 return '';
+             }
+             const labels = [];
+             const values = [];
+             data.forEach(row => {
+                 labels.push(row[chartLabelField]);
+                 values.push(Number(row[chartValueField]) || 0);
+             });
+             const dataset = {
+                 labels,
+                 values
+             };
+             const json = JSON.stringify(dataset);
+             return `
+                 <div class="rr-chart">
+                     <canvas id="rrChart"></canvas>
+                     <script type="text/javascript">
+                         (function() {
+                             var data = ${json};
+                             function renderChart() {
+                                 if (!window.Chart) {
+                                     setTimeout(renderChart, 100);
+                                     return;
+                                 }
+                                 var ctx = document.getElementById('rrChart');
+                                 if (!ctx) return;
+                                 new Chart(ctx, {
+                                     type: '${chartType}',
+                                     data: {
+                                         labels: data.labels,
+                                         datasets: [{
+                                             label: '${chartValueField}',
+                                             data: data.values,
+                                             backgroundColor: 'rgba(54, 162, 235, 0.2)',
+                                             borderColor: 'rgba(54, 162, 235, 1)',
+                                             borderWidth: 1,
+                                             fill: ${chartType === chartTypes.line ? 'false' : 'true'}
+                                         }]
+                                     },
+                                     options: {
+                                         responsive: true,
+                                         maintainAspectRatio: false
+                                     }
+                                 });
+                             }
+                             renderChart();
+                         })();
+                     </script>
+                 </div>`;
+         };
+ 
+         const addResultsToForm = (form, data, chartType, chartLabelField, chartValueField) => {
+             const htmlField = form.addField({
+                 id: 'custpage_rr_results',
+                 type: ui.FieldType.INLINEHTML,
+                 label: 'Results'
+             });
+             const chartHtml = buildChartHtml(chartType, chartLabelField, chartValueField, data);
+             const tableHtml = convertToTable(form, data);
+             const styles = `
+                 <style>
+                     .rr-table { border-collapse: collapse; width: 100%; }
+                     .rr-table th, .rr-table td { border: 1px solid #ccc; padding: 4px 8px; }
+                     .rr-table th { background-color: #f1f1f1; }
+                     .rr-chart { width: 100%; height: 400px; margin-bottom: 16px; }
+                     .rr-empty { font-style: italic; color: #666; margin: 12px 0; }
+                </style>
+                <script src="${CHART_JS_CDN}"></script>
+            `;
+             htmlField.defaultValue = `${styles}${chartHtml}${tableHtml}`;
+         };
+ 
+         const onRequest = (context) => {
+             const request = context.request;
+             const response = context.response;
+             const params = request.parameters;
+             const reportId = params.report;
+             if (!reportId) {
+                 renderReportCatalog(context);
+                 return;
+             }
+ 
+             const reportConfig = record.load({ type: CUSTOM_RECORD_TYPE, id: reportId });
+             const title = reportConfig.getValue({ fieldId: 'name' });
+             const description = reportConfig.getValue({ fieldId: DESCRIPTION_FIELD });
+             const dataSource = reportConfig.getValue({ fieldId: DATASOURCE_FIELD });
+             const savedSearchId = reportConfig.getValue({ fieldId: SAVED_SEARCH_FIELD });
+             const suiteQL = reportConfig.getValue({ fieldId: SUITEQL_FIELD });
+             const chartType = reportConfig.getValue({ fieldId: CHART_TYPE_FIELD }) || chartTypes.none;
+             const chartLabelField = reportConfig.getValue({ fieldId: CHART_LABEL_FIELD });
+             const chartValueField = reportConfig.getValue({ fieldId: CHART_VALUE_FIELD });
+             const filterConfigText = reportConfig.getValue({ fieldId: FILTER_CONFIG_FIELD });
+ 
+             const filters = parseFilterConfiguration(filterConfigText);
+             const filterValues = extractFilterValues(filters, params);
+ 
+             let data = [];
+             if (dataSource === dataSourceTypes.savedSearch && savedSearchId) {
+                 data = runSavedSearch(savedSearchId, filters, filterValues);
+             } else if (dataSource === dataSourceTypes.suiteql) {
+                 data = runSuiteQL(suiteQL, filters, filterValues);
+             }
+ 
+             if (params.custpage_rr_action === ACTION_DOWNLOAD || params.action === ACTION_DOWNLOAD) {
+                 const csv = buildDownloadCsv(data);
+                 response.writeFile({
+                     file: file.create({
+                         name: `${title || 'report'}.csv`,
+                         fileType: file.Type.CSV,
+                         contents: csv
+                     })
+                 });
+                 return;
+             }
+ 
+             const form = ui.createForm({ title: title || 'Report Runner' });
+             if (description) {
+                 form.addField({
+                     id: 'custpage_rr_description',
+                     type: ui.FieldType.INLINEHTML,
+                     label: 'Description',
+                     defaultValue: `<div class="rr-description">${description}</div>`
+                 });
+             }
+ 
+             addFilterFieldsToForm(form, filters, params);
+             addResultsToForm(form, data, chartType, chartLabelField, chartValueField);
+             addDownloadButton(form);
+ 
+             response.writePage(form);
+         };
+ 
+         return { onRequest };
+     });

--- a/FileCabinet/SuiteScripts/ReportRunner/report_suitelet_client.js
+++ b/FileCabinet/SuiteScripts/ReportRunner/report_suitelet_client.js
@@ -1,0 +1,20 @@
+/**
+ * @NApiVersion 2.1
+ * @NScriptType ClientScript
+ */
+define([], () => {
+    const onDownload = () => {
+        const actionField = document.getElementById('custpage_rr_action');
+        if (actionField) {
+            actionField.value = 'download';
+        }
+        const form = document.forms[0];
+        if (form) {
+            form.submit();
+        }
+    };
+
+    return {
+        onDownload
+    };
+});

--- a/Objects/customlist_customlist_rr_charttype.xml
+++ b/Objects/customlist_customlist_rr_charttype.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<customList scriptid="customlist_rr_charttype">
+    <name>Report Runner Chart Types</name>
+    <isinactive>F</isinactive>
+    <customValue scriptid="custvalue_rr_chart_none">
+        <value>None</value>
+        <abbreviation>none</abbreviation>
+        <isinactive>F</isinactive>
+        <valueid>1</valueid>
+    </customValue>
+    <customValue scriptid="custvalue_rr_chart_bar">
+        <value>Bar</value>
+        <abbreviation>bar</abbreviation>
+        <isinactive>F</isinactive>
+        <valueid>2</valueid>
+    </customValue>
+    <customValue scriptid="custvalue_rr_chart_line">
+        <value>Line</value>
+        <abbreviation>line</abbreviation>
+        <isinactive>F</isinactive>
+        <valueid>3</valueid>
+    </customValue>
+    <customValue scriptid="custvalue_rr_chart_pie">
+        <value>Pie</value>
+        <abbreviation>pie</abbreviation>
+        <isinactive>F</isinactive>
+        <valueid>4</valueid>
+    </customValue>
+    <customValue scriptid="custvalue_rr_chart_doughnut">
+        <value>Doughnut</value>
+        <abbreviation>doughnut</abbreviation>
+        <isinactive>F</isinactive>
+        <valueid>5</valueid>
+    </customValue>
+</customList>

--- a/Objects/customlist_customlist_rr_datasource.xml
+++ b/Objects/customlist_customlist_rr_datasource.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<customList scriptid="customlist_rr_datasource">
+    <name>Report Runner Data Sources</name>
+    <isinactive>F</isinactive>
+    <customValue scriptid="custvalue_rr_ds_savedsearch">
+        <value>Saved Search</value>
+        <abbreviation>SAVED_SEARCH</abbreviation>
+        <isinactive>F</isinactive>
+        <valueid>1</valueid>
+    </customValue>
+    <customValue scriptid="custvalue_rr_ds_suiteql">
+        <value>SuiteQL</value>
+        <abbreviation>SUITEQL</abbreviation>
+        <isinactive>F</isinactive>
+        <valueid>2</valueid>
+    </customValue>
+</customList>

--- a/Objects/customrecordtype_customrecord_rr_report.xml
+++ b/Objects/customrecordtype_customrecord_rr_report.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<customRecordType scriptid="customrecord_rr_report">
+    <recordname>Report Runner Configuration</recordname>
+    <pluralrecordname>Report Runner Configurations</pluralrecordname>
+    <singularrecordname>Report Runner Configuration</singularrecordname>
+    <recordid>Report Runner Configuration</recordid>
+    <accesslevel>2</accesslevel>
+    <allowattachments>F</allowattachments>
+    <allowinlinesourcing>F</allowinlinesourcing>
+    <allowquickadd>F</allowquickadd>
+    <description>Configuration for Suitelet-driven reports that can source data from Saved Searches or SuiteQL.</description>
+    <enableadvancedsearch>T</enableadvancedsearch>
+    <enablemassupdates>T</enablemassupdates>
+    <enablenumbering>T</enablenumbering>
+    <enablenumberingupdate>F</enablenumberingupdate>
+    <isordered>F</isordered>
+    <recordhelp><![CDATA[
+        <p>Use this record to configure interactive reports for the Report Runner Suitelet. Each record can source its data from a Saved Search or SuiteQL query.</p>
+        <p>Populate the filter configuration with JSON describing input filters. Example:</p>
+        <pre>[{"id":"trandate_from","label":"Start Date","type":"date","searchField":"trandate","operator":"ONORAFTER","suiteqlParamIndex":0}]</pre>
+    ]]></recordhelp>
+    <customfields>
+        <customfield scriptid="custrecord_rr_description">
+            <label>Description</label>
+            <fieldtype>RICHTEXT</fieldtype>
+            <storevalue>T</storevalue>
+            <displaytype>NORMAL</displaytype>
+            <showinlist>F</showinlist>
+        </customfield>
+        <customfield scriptid="custrecord_rr_datasource">
+            <label>Data Source</label>
+            <fieldtype>LIST</fieldtype>
+            <sourcelist>customlist_rr_datasource</sourcelist>
+            <storevalue>T</storevalue>
+            <displaytype>NORMAL</displaytype>
+            <defaultvalue>SAVED_SEARCH</defaultvalue>
+            <help>Select how the report should fetch data.</help>
+        </customfield>
+        <customfield scriptid="custrecord_rr_savedsearch">
+            <label>Saved Search</label>
+            <fieldtype>LIST</fieldtype>
+            <selectrecordtype>savedsearch</selectrecordtype>
+            <storevalue>T</storevalue>
+            <displaytype>NORMAL</displaytype>
+            <help>Choose the saved search to run when the data source is Saved Search.</help>
+        </customfield>
+        <customfield scriptid="custrecord_rr_suiteql">
+            <label>SuiteQL</label>
+            <fieldtype>LONGTEXT</fieldtype>
+            <storevalue>T</storevalue>
+            <displaytype>NORMAL</displaytype>
+            <help>Provide SuiteQL text when the data source is SuiteQL. Use ? placeholders for filter parameters and map them via the filter configuration.</help>
+        </customfield>
+        <customfield scriptid="custrecord_rr_chart_type">
+            <label>Chart Type</label>
+            <fieldtype>LIST</fieldtype>
+            <sourcelist>customlist_rr_charttype</sourcelist>
+            <storevalue>T</storevalue>
+            <displaytype>NORMAL</displaytype>
+            <defaultvalue>none</defaultvalue>
+        </customfield>
+        <customfield scriptid="custrecord_rr_chart_label">
+            <label>Chart Label Field</label>
+            <fieldtype>TEXT</fieldtype>
+            <storevalue>T</storevalue>
+            <displaytype>NORMAL</displaytype>
+            <help>Provide the name of the field in the result set that should be used as chart labels.</help>
+        </customfield>
+        <customfield scriptid="custrecord_rr_chart_value">
+            <label>Chart Value Field</label>
+            <fieldtype>TEXT</fieldtype>
+            <storevalue>T</storevalue>
+            <displaytype>NORMAL</displaytype>
+            <help>Provide the name of the field in the result set that should be used for chart values. Values will be coerced to numbers.</help>
+        </customfield>
+        <customfield scriptid="custrecord_rr_filter_config">
+            <label>Filter Configuration</label>
+            <fieldtype>LONGTEXT</fieldtype>
+            <storevalue>T</storevalue>
+            <displaytype>NORMAL</displaytype>
+            <help>JSON array describing filters to render on the Suitelet. Each entry should include id, label, type, and optional operator, searchField, select options, and suiteqlParamIndex.</help>
+        </customfield>
+    </customfields>
+</customRecordType>

--- a/Objects/script_custscript_rr_report_suitelet.xml
+++ b/Objects/script_custscript_rr_report_suitelet.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<script scriptid="custscript_rr_report_suitelet">
+    <name>Report Runner Suitelet</name>
+    <description>Entry point for configurable reporting Suitelet.</description>
+    <scripttype>SUITELET</scripttype>
+    <status>RELEASED</status>
+    <notifyowneronupdates>F</notifyowneronupdates>
+    <scriptfile>SuiteScripts/ReportRunner/report_suitelet.js</scriptfile>
+    <libraries />
+</script>

--- a/Objects/scriptdeployment_customdeploy_rr_report_suitelet.xml
+++ b/Objects/scriptdeployment_customdeploy_rr_report_suitelet.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scriptDeployment scriptid="customdeploy_rr_report_suitelet">
+    <script>custscript_rr_report_suitelet</script>
+    <title>Report Runner Suitelet</title>
+    <status>RELEASED</status>
+    <isdeployed>T</isdeployed>
+    <loglevel>DEBUG</loglevel>
+    <url>customscript_rr_report_suitelet</url>
+</scriptDeployment>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,107 @@
-# report-runner
-SDF Project to make it simple to publish interactive reports in NetSuite, utilizing SuiteQL and Saved Searches.
+# Report Runner
+
+Report Runner is a SuiteCloud Development Framework (SDF) project that delivers a configurable Suitelet for running and visualising NetSuite reports. Each report is defined by a custom record that allows you to wire up Saved Searches or SuiteQL, configure filters, render charts, and export results.
+
+## Features
+
+- **Configurable Suitelet** – Deploy the included Suitelet and pass a report configuration id to render interactive reports.
+- **Flexible Data Sources** – Run reports backed by either Saved Searches or SuiteQL statements.
+- **Dynamic Filters** – Describe the filters you want to expose using JSON, and they will render on the Suitelet automatically with server-side filtering.
+- **Charting Support** – Built-in Chart.js integration to display bar, line, pie, or doughnut visualisations.
+- **Downloadable Data** – One-click CSV export that respects your current filters.
+- **In-app Documentation** – Record-level help text documents how to configure the solution from inside NetSuite.
+
+## Project Structure
+
+```
+FileCabinet/
+  SuiteScripts/
+    ReportRunner/
+      report_suitelet.js           # Suitelet implementation
+      report_suitelet_client.js    # Client script for front-end controls
+Objects/
+  customlist_customlist_rr_charttype.xml   # Chart type list values
+  customlist_customlist_rr_datasource.xml  # Data source list values
+  customrecordtype_customrecord_rr_report.xml # Report configuration custom record type
+  script_custscript_rr_report_suitelet.xml     # Suitelet script definition
+  scriptdeployment_customdeploy_rr_report_suitelet.xml # Default deployment
+manifest.xml
+deploy.xml
+```
+
+## Getting Started
+
+1. **Install the project** – Deploy the SDF project to your target NetSuite account using SDF CLI or Web IDE.
+2. **Deploy the Suitelet** – The included deployment is enabled by default. Adjust roles and audience as needed in NetSuite.
+3. **Create report configurations** – Navigate to *Report Runner Configurations* and create a record for each report.
+4. **Open the Suitelet** – Launch the Suitelet without parameters to see all available reports, or pass `report={internalId}` in the URL to jump straight to a configuration.
+
+## Configuring Reports
+
+Each report record supports the following key fields:
+
+| Field | Purpose |
+| --- | --- |
+| **Data Source** | Choose between Saved Search or SuiteQL. |
+| **Saved Search** | Reference the saved search to execute when using the Saved Search data source. |
+| **SuiteQL** | Provide the SuiteQL text. Use `?` placeholders for parameters supplied by filters. |
+| **Chart Type** | Select a visualisation or "None" to omit charts. |
+| **Chart Label Field** | Name of the field in the result set to use for chart labels. |
+| **Chart Value Field** | Name of the numeric field used for chart values. |
+| **Filter Configuration** | JSON array describing filters rendered on the Suitelet. |
+
+### Filter Configuration JSON
+
+Define each filter as an object in the JSON array. Supported properties:
+
+- `id` (string) – Identifier used to reference the filter value.
+- `label` (string) – Display label on the form.
+- `type` (string) – `text`, `select`, `date`, `checkbox`, `float`, or `integer`.
+- `operator` (string, optional) – NetSuite search operator (e.g. `ONORAFTER`, `ANYOF`). Defaults to `CONTAINS` for text and `ANYOF` for select filters.
+- `searchField` (string, optional) – Saved search field id used when applying the filter.
+- `source` (array, optional) – For select filters, provide option objects `{ value, text }`.
+- `suiteqlParamIndex` (number, optional) – Zero-based index of the parameter position for SuiteQL queries.
+
+**Example**
+
+```json
+[
+  {
+    "id": "trandate_from",
+    "label": "Start Date",
+    "type": "date",
+    "operator": "ONORAFTER",
+    "searchField": "trandate",
+    "suiteqlParamIndex": 0
+  },
+  {
+    "id": "status",
+    "label": "Status",
+    "type": "select",
+    "operator": "ANYOF",
+    "searchField": "status",
+    "source": [
+      { "value": "SalesOrd:A", "text": "Pending Approval" },
+      { "value": "SalesOrd:B", "text": "Pending Fulfillment" }
+    ]
+  }
+]
+```
+
+## Chart Rendering
+
+Charts are powered by [Chart.js](https://www.chartjs.org/) via CDN. Ensure the target roles have access to external script loading, or host the library locally if your security policy requires it.
+
+## Downloading Results
+
+The Suitelet renders a **Download CSV** button that submits the form with the current filters and returns a CSV file containing the first 2,000 rows from the data set.
+
+## Extending the Solution
+
+- Add additional custom lists or checkboxes to the record type to capture more metadata.
+- Build role-specific deployments of the Suitelet by copying and editing the deployment object.
+- Swap the Chart.js CDN for an on-account hosted version by updating `CHART_JS_CDN` in `report_suitelet.js`.
+
+## Support
+
+Create issues or pull requests in this repository if you discover bugs or have enhancement ideas.

--- a/deploy.xml
+++ b/deploy.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<deploy>
+    <configuration>
+        <recordtypes>
+            <recordtype>customrecord_rr_report</recordtype>
+        </recordtypes>
+        <customlists>
+            <customlist>customlist_rr_datasource</customlist>
+            <customlist>customlist_rr_charttype</customlist>
+        </customlists>
+        <scripts>
+            <script>custscript_rr_report_suitelet</script>
+        </scripts>
+    </configuration>
+</deploy>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Report Runner Documentation
+
+This directory supplements the root `README.md` with configuration examples that administrators can copy into NetSuite.
+
+- `filter-config-example.json` – Sample JSON showing how to expose Start/End Date and Status filters for a sales order report. Copy the JSON into the **Filter Configuration** field on a Report Runner Configuration record and adjust the values to suit your search or SuiteQL.
+
+For detailed setup instructions, see the project root README and the help text embedded in the custom record type.

--- a/docs/filter-config-example.json
+++ b/docs/filter-config-example.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": "trandate_from",
+    "label": "Start Date",
+    "type": "date",
+    "operator": "ONORAFTER",
+    "searchField": "trandate",
+    "suiteqlParamIndex": 0
+  },
+  {
+    "id": "trandate_to",
+    "label": "End Date",
+    "type": "date",
+    "operator": "ONORBEFORE",
+    "searchField": "trandate",
+    "suiteqlParamIndex": 1
+  },
+  {
+    "id": "status",
+    "label": "Status",
+    "type": "select",
+    "operator": "ANYOF",
+    "searchField": "status",
+    "source": [
+      { "value": "SalesOrd:A", "text": "Pending Approval" },
+      { "value": "SalesOrd:B", "text": "Pending Fulfillment" },
+      { "value": "SalesOrd:D", "text": "Pending Billing" }
+    ],
+    "suiteqlParamIndex": 2
+  }
+]

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest projecttype="SDF" appid="com.example.reportrunner" scriptid="customdeploy_rr_report_suitelet">
+    <projecttitle>Report Runner</projecttitle>
+    <projectdescription>Configurable Suitelet-driven reporting utility with SuiteQL/Saved Search data sources and charting support.</projectdescription>
+    <publisher>Report Runner</publisher>
+    <targetversion>2023.2</targetversion>
+</manifest>


### PR DESCRIPTION
## Summary
- add a Suitelet implementation that renders configurable reports, supports charting, and exposes CSV downloads
- define the supporting custom record, lists, and deployment assets for the Report Runner project
- expand repository documentation with setup guidance and filter configuration examples

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ee8b12d1b48326b1ef68b4cedf56f2